### PR TITLE
Updates regex for circle github url

### DIFF
--- a/lib/circle-ci-status-view.coffee
+++ b/lib/circle-ci-status-view.coffee
@@ -23,7 +23,8 @@ module.exports =
     fetchBuildArray: ->
       url = @repo.getOriginUrl()
       return unless url?
-      match = url.match /.*github\.com:(.*)\/(.*)\.git/
+      # match = url.match /.*github\.com:(.*)\/(.*)\.git/
+      match = url.match /.*github\.com\/(.*)\/(.*)\.git/
       [_, @username, @projectname] = match if match?
       return unless @username? && @projectname?
       @api.lastBuild @username, @projectname, (buildArray) =>


### PR DESCRIPTION
The regex seemed to be failing when analyzing the github url which caused the package to fail.

Once I made this change, the status icon started to display correctly.
