### PR TITLE
fix: change regex to support github.com:org/repo format

### DIFF
--- a/lib/circle-ci-status-view.coffee
+++ b/lib/circle-ci-status-view.coffee
@@ -61,7 +61,8 @@ module.exports =
         when 'fixed'    then 'icon-check'
         when 'failed'   then 'icon-alert'
         when 'canceled' then 'icon-x'
-        else                 'icon-slash'
+        when 'no_tests' then 'icon-circle-slash'
+        else                 'icon-circle-slash'
 
       @statusIcon.removeClass().addClass "icon #{icon}"
 


### PR DESCRIPTION
Hi @cliffrowley,

Found this really useful, found an issue when I installed as it wouldn't recognise my github repo, so put in a fix! Let me know what you think:

Originally the regex match would fail if it found a repo in the format github.com:org/repo, so changed the regex slightly to accept both a colon and a forward slash.

Also, "fixed" and "no_tests" are valid CircleCI statuses that happen whenever a build passes right after a fail (fixed) and when they can't find any tests (no_tests), so added those in.
