### PR TITLE
Link to build result page

### DIFF
--- a/lib/circle-ci-status-view.coffee
+++ b/lib/circle-ci-status-view.coffee
@@ -7,7 +7,7 @@ module.exports =
     @content: ->
       @div class: 'circle-ci-status-view inline-block', =>
         @span outlet: 'statusIcon'
-        @span outlet: 'statusLabel'
+        @a outlet: 'statusLabel'
 
     initialize: ->
       @repo          = atom.project.getRepo()
@@ -49,6 +49,7 @@ module.exports =
           build = buildArray[0]
           @showStatus build.status
           @statusLabel.text "#{build.build_num} (#{build.branch})"
+          @statusLabel.attr("href", "#{build.build_url}")
         else
           @showStatus 'none'
           @statusLabel.text "(no build status available)"


### PR DESCRIPTION
This will make the build number clickable and link to the build page over at Circle CI.