### PR TITLE
Adding details on Atom config of CircleCI API Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@ Shows the [Circle CI](http://circleci.com) build status for the current project 
 
 ## Configuring
 
-Create an API token in your Circle CI [dashboard](https://circleci.com/account/api) and add it to the Circle CI package configuration in Atom's settings. Keys from the repo settings page will not work.
+Create an API token in your Circle CI [dashboard](https://circleci.com/account/api) and add it to the Circle CI package configuration in Atom's settings (Atom > Open Your Config).
+
+```
+  "circle-ci":
+    apiToken: "CIRCLE API TOKEN"
+```
+
+Keys from the repo settings page will not work.
 
 ## Using
 


### PR DESCRIPTION
This is a cool little plugin. I can't believe I hadn't looked for something like this sooner! Great job!

Just added a little to the `README.md` to explain what needs to be setup in the user's Atom configuration to get it working. I had to peak into the code to figure out exactly how this needed to be set.